### PR TITLE
[Bug fix] Param key type mismatch

### DIFF
--- a/lib/valid_field.ex
+++ b/lib/valid_field.ex
@@ -168,7 +168,7 @@ defmodule ValidField do
   end
 
   defp _is_invalid_for(%{model: model, changeset_func: changeset}, field, value) do
-    params = Map.put(%{},field, value)
+    params = Map.put(%{}, stringify_field(field), value)
     changeset.(model, params).errors
     |> Dict.has_key?(field)
   end
@@ -177,4 +177,7 @@ defmodule ValidField do
     changeset.errors
     |> Dict.has_key?(field)
   end
+
+  defp stringify_field(field) when is_atom(field), do: Atom.to_string(field)
+  defp stringify_field(field) when is_binary(field), do: field
 end

--- a/test/support/model.ex
+++ b/test/support/model.ex
@@ -18,4 +18,10 @@ defmodule ValidField.Support.Model do
     |> cast(params, @required_fields, @optional_fields)
     |> validate_length(:first_name, min: 1)
   end
+
+  def other_changeset(model, params) do
+    params = Map.merge(params, %{"title" => "Grand Poobah"})
+
+    changeset(model, params)
+  end
 end

--- a/test/valid_field_test.exs
+++ b/test/valid_field_test.exs
@@ -109,4 +109,9 @@ defmodule ValidFieldTest do
     Model.changeset(%Model{}, %{})
     |> ValidField.assert_invalid_field(:first_name)
   end
+
+  test "passing field with key type mismatch from changeset params" do
+    ValidField.with_changeset(%Model{}, &Model.other_changeset/2)
+    |> ValidField.assert_valid_field(:first_name, ["Test"])
+  end
 end


### PR DESCRIPTION
In Ecto when you are attempting to cast params that have a mix of string
and atoms Ecto raises an error:
https://github.com/elixir-lang/ecto/blob/master/lib/ecto/changeset.ex#L428-L429

This fix will normalize all fields in the final param map to a string.
Phoenix params come in with string keys so this should be the preferred
normalization direction.
