### PR TITLE
Test against elixir 1.2.6 and 1.3.2 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: elixir
 elixir:
   - 1.1.1
   - 1.2.6
+  - 1.3.1
 cache:
  - _build
  - deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: elixir
 elixir:
   - 1.1.1
   - 1.2.6
-  - 1.3.1
+  - 1.3.2
 cache:
  - _build
  - deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: elixir
-elixir: 1.1.1
+elixir:
+  - 1.1.1
+  - 1.2.0
 cache:
  - _build
  - deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: elixir
 elixir:
   - 1.1.1
-  - 1.2.0
+  - 1.2.6
 cache:
  - _build
  - deps


### PR DESCRIPTION
The build appears to be green on 1.2 (yet red on 1.3), so it's good to know the source code is not bound to 1.1.1.
