### PR TITLE
Remove ex_unit assert

### DIFF
--- a/lib/valid_field.ex
+++ b/lib/valid_field.ex
@@ -1,11 +1,10 @@
 defmodule ValidField do
-  import ExUnit.Assertions, only: [assert: 2]
   @moduledoc ~S"""
   ValidField allows for unit testing values against a changeset.
   """
 
   @doc """
-  Raises an ExUnit.AssertionError when the values for the field are invalid for
+  Raises an ValidField.ValidationException when the values for the field are invalid for
   the changset provided. Returns the original changset map from `with_changeset/1`
   to allow subsequent calls to be piped
 
@@ -15,7 +14,7 @@ defmodule ValidField do
       ...> |> ValidField.assert_valid_field(:last_name, ["Value"])
       iex> ValidField.with_changeset(%Model{})
       ...> |> ValidField.assert_valid_field(:first_name, [nil, ""])
-      ** (ExUnit.AssertionError) Expected the following values to be valid for "first_name": nil, ""
+      ** (ValidField.ValidationException) Expected the following values to be valid for "first_name": nil, ""
   """
   @spec assert_valid_field(map, atom, list) :: map
   def assert_valid_field(changeset, field, values) do
@@ -24,7 +23,9 @@ defmodule ValidField do
       |> map_value_assertions(field, values)
       |> Enum.filter_map(fn {_key, value} -> value end, fn {key, _value} -> key end)
 
-    assert invalid_values == [], "Expected the following values to be valid for #{inspect Atom.to_string(field)}: #{_format_values invalid_values}"
+    if invalid_values != [] do
+      raise ValidField.ValidationException, field: field, values: values, validity: "valid"
+    end
 
     changeset
   end
@@ -37,7 +38,7 @@ defmodule ValidField do
       ...> |> ValidField.assert_valid_field(:first_name)
       iex> ValidField.with_changeset(%Model{})
       ...> |> ValidField.assert_valid_field(:first_name)
-      ** (ExUnit.AssertionError) Expected the following values to be valid for "first_name": nil
+      ** (ValidField.ValidationException) Expected the following values to be valid for "first_name": nil
   """
   @spec assert_valid_field(map, atom) :: map
   def assert_valid_field(changeset, field) do
@@ -54,7 +55,7 @@ defmodule ValidField do
       ...> |> ValidField.assert_valid_fields([:first_name, :last_name])
       iex> ValidField.with_changeset(%Model{first_name: "Test", last_name: "Something"})
       ...> |> ValidField.assert_valid_fields([:first_name, :last_name])
-      ** (ExUnit.AssertionError) Expected the following values to be valid for "first_name": nil
+      ** (ValidField.ValidationException) Expected the following values to be valid for "first_name": nil
   """
   @spec assert_valid_fields(map, list) :: map
   def assert_valid_fields(changeset, fields) when is_list(fields) do
@@ -62,7 +63,7 @@ defmodule ValidField do
   end
 
   @doc """
-  Raises an ExUnit.AssertionError when the values for the field are valid for
+  Raises an ValidField.ValidationException when the values for the field are valid for
   the changset provided. Returns the original changset map from `with_changeset/1`
   to allow subsequent calls to be piped
 
@@ -72,7 +73,7 @@ defmodule ValidField do
       ...> |> ValidField.assert_invalid_field(:first_name, [""])
       iex> ValidField.with_changeset(%Model{})
       ...> |> ValidField.assert_invalid_field(:first_name, ["Test"])
-      ** (ExUnit.AssertionError) Expected the following values to be invalid for "first_name": "Test"
+      ** (ValidField.ValidationException) Expected the following values to be invalid for "first_name": "Test"
   """
   @spec assert_invalid_field(map, atom, list) :: map
   def assert_invalid_field(changeset, field, values) do
@@ -81,7 +82,9 @@ defmodule ValidField do
       |> map_value_assertions(field, values)
       |> Enum.filter_map(fn {_key, value} -> !value end, fn {key, _value} -> key end)
 
-    assert valid_values == [], "Expected the following values to be invalid for #{inspect Atom.to_string(field)}: #{_format_values valid_values}"
+    if valid_values != [] do
+      raise ValidField.ValidationException, field: field, values: valid_values, validity: "invalid"
+    end
 
     changeset
   end
@@ -94,7 +97,7 @@ defmodule ValidField do
       ...> |> ValidField.assert_invalid_field(:first_name)
       iex> ValidField.with_changeset(%Model{first_name: "Test"})
       ...> |> ValidField.assert_invalid_field(:first_name)
-      ** (ExUnit.AssertionError) Expected the following values to be invalid for "first_name": "Test"
+      ** (ValidField.ValidationException) Expected the following values to be invalid for "first_name": "Test"
   """
   @spec assert_invalid_field(map, atom) :: map
   def assert_invalid_field(changeset, field) do
@@ -111,7 +114,7 @@ defmodule ValidField do
       ...> |> ValidField.assert_invalid_fields([:first_name])
       iex> ValidField.with_changeset(%Model{first_name: "Test"})
       ...> |> ValidField.assert_invalid_fields([:first_name])
-      ** (ExUnit.AssertionError) Expected the following values to be invalid for "first_name": "Test"
+      ** (ValidField.ValidationException) Expected the following values to be invalid for "first_name": "Test"
   """
   @spec assert_invalid_fields(map, list) :: map
   def assert_invalid_fields(changeset, fields) when is_list(fields) do
@@ -170,12 +173,6 @@ defmodule ValidField do
   @spec put_params(map, map) :: map
   def put_params(changeset, params) when is_map(changeset) do
     Map.put(changeset, :params, params)
-  end
-
-  defp _format_values(values) do
-    values
-    |> Enum.map(&inspect/1)
-    |> Enum.join(", ")
   end
 
   defp map_value_assertions(changeset, field, values) do

--- a/lib/valid_field.ex
+++ b/lib/valid_field.ex
@@ -4,7 +4,7 @@ defmodule ValidField do
   """
 
   @doc """
-  Raises an ValidField.ValidationException when the values for the field are invalid for
+  Raises an ValidField.ValidationError when the values for the field are invalid for
   the changset provided. Returns the original changset map from `with_changeset/1`
   to allow subsequent calls to be piped
 
@@ -14,7 +14,7 @@ defmodule ValidField do
       ...> |> ValidField.assert_valid_field(:last_name, ["Value"])
       iex> ValidField.with_changeset(%Model{})
       ...> |> ValidField.assert_valid_field(:first_name, [nil, ""])
-      ** (ValidField.ValidationException) Expected the following values to be valid for "first_name": nil, ""
+      ** (ValidField.ValidationError) Expected the following values to be valid for "first_name": nil, ""
   """
   @spec assert_valid_field(map, atom, list) :: map
   def assert_valid_field(changeset, field, values) do
@@ -24,7 +24,7 @@ defmodule ValidField do
       |> Enum.filter_map(fn {_key, value} -> value end, fn {key, _value} -> key end)
 
     if invalid_values != [] do
-      raise ValidField.ValidationException, field: field, values: values, validity: "valid"
+      raise ValidField.ValidationError, field: field, values: values, validity: "valid"
     end
 
     changeset
@@ -38,7 +38,7 @@ defmodule ValidField do
       ...> |> ValidField.assert_valid_field(:first_name)
       iex> ValidField.with_changeset(%Model{})
       ...> |> ValidField.assert_valid_field(:first_name)
-      ** (ValidField.ValidationException) Expected the following values to be valid for "first_name": nil
+      ** (ValidField.ValidationError) Expected the following values to be valid for "first_name": nil
   """
   @spec assert_valid_field(map, atom) :: map
   def assert_valid_field(changeset, field) do
@@ -55,7 +55,7 @@ defmodule ValidField do
       ...> |> ValidField.assert_valid_fields([:first_name, :last_name])
       iex> ValidField.with_changeset(%Model{first_name: "Test", last_name: "Something"})
       ...> |> ValidField.assert_valid_fields([:first_name, :last_name])
-      ** (ValidField.ValidationException) Expected the following values to be valid for "first_name": nil
+      ** (ValidField.ValidationError) Expected the following values to be valid for "first_name": nil
   """
   @spec assert_valid_fields(map, list) :: map
   def assert_valid_fields(changeset, fields) when is_list(fields) do
@@ -63,7 +63,7 @@ defmodule ValidField do
   end
 
   @doc """
-  Raises an ValidField.ValidationException when the values for the field are valid for
+  Raises an ValidField.ValidationError when the values for the field are valid for
   the changset provided. Returns the original changset map from `with_changeset/1`
   to allow subsequent calls to be piped
 
@@ -73,7 +73,7 @@ defmodule ValidField do
       ...> |> ValidField.assert_invalid_field(:first_name, [""])
       iex> ValidField.with_changeset(%Model{})
       ...> |> ValidField.assert_invalid_field(:first_name, ["Test"])
-      ** (ValidField.ValidationException) Expected the following values to be invalid for "first_name": "Test"
+      ** (ValidField.ValidationError) Expected the following values to be invalid for "first_name": "Test"
   """
   @spec assert_invalid_field(map, atom, list) :: map
   def assert_invalid_field(changeset, field, values) do
@@ -83,7 +83,7 @@ defmodule ValidField do
       |> Enum.filter_map(fn {_key, value} -> !value end, fn {key, _value} -> key end)
 
     if valid_values != [] do
-      raise ValidField.ValidationException, field: field, values: valid_values, validity: "invalid"
+      raise ValidField.ValidationError, field: field, values: valid_values, validity: "invalid"
     end
 
     changeset
@@ -97,7 +97,7 @@ defmodule ValidField do
       ...> |> ValidField.assert_invalid_field(:first_name)
       iex> ValidField.with_changeset(%Model{first_name: "Test"})
       ...> |> ValidField.assert_invalid_field(:first_name)
-      ** (ValidField.ValidationException) Expected the following values to be invalid for "first_name": "Test"
+      ** (ValidField.ValidationError) Expected the following values to be invalid for "first_name": "Test"
   """
   @spec assert_invalid_field(map, atom) :: map
   def assert_invalid_field(changeset, field) do
@@ -114,7 +114,7 @@ defmodule ValidField do
       ...> |> ValidField.assert_invalid_fields([:first_name])
       iex> ValidField.with_changeset(%Model{first_name: "Test"})
       ...> |> ValidField.assert_invalid_fields([:first_name])
-      ** (ValidField.ValidationException) Expected the following values to be invalid for "first_name": "Test"
+      ** (ValidField.ValidationError) Expected the following values to be invalid for "first_name": "Test"
   """
   @spec assert_invalid_fields(map, list) :: map
   def assert_invalid_fields(changeset, fields) when is_list(fields) do

--- a/lib/valid_field/validation_error.ex
+++ b/lib/valid_field/validation_error.ex
@@ -1,6 +1,6 @@
-defmodule ValidField.ValidationException do
+defmodule ValidField.ValidationError do
   @moduledoc """
-  Raised my exception.
+  Raises validation error.
   """
 
   defexception [:field, :values, :validity]

--- a/lib/valid_field/validation_exception.ex
+++ b/lib/valid_field/validation_exception.ex
@@ -1,0 +1,21 @@
+defmodule ValidField.ValidationException do
+  @moduledoc """
+  Raised my exception.
+  """
+
+  defexception [:field, :values, :validity]
+
+  def message(exception) do
+    formatted_field = inspect(Atom.to_string(exception.field))
+    formatted_values = _format_values(exception.values)
+    validity = exception.validity
+
+    "Expected the following values to be #{validity} for #{formatted_field}: #{formatted_values}"
+  end
+
+  defp _format_values(values) do
+    values
+    |> Enum.map(&inspect/1)
+    |> Enum.join(", ")
+  end
+end

--- a/test/valid_field_test.exs
+++ b/test/valid_field_test.exs
@@ -9,17 +9,17 @@ defmodule ValidFieldTest do
     |> ValidField.assert_valid_field(:last_name, ["", nil, "Something"])
     |> ValidField.assert_valid_field(:title, ["", nil, "Something else"])
 
-    assert_raise ExUnit.AssertionError, "Expected the following values to be invalid for \"first_name\": \"Test\", \"Good Value\"", fn ->
+    assert_raise ValidField.ValidationException, "Expected the following values to be invalid for \"first_name\": \"Test\", \"Good Value\"", fn ->
       ValidField.with_changeset(%Model{})
       |> ValidField.assert_invalid_field(:first_name, ["Test", "Good Value"])
     end
 
-    assert_raise ExUnit.AssertionError, "Expected the following values to be invalid for \"last_name\": \"\", nil, \"Something\"", fn ->
+    assert_raise ValidField.ValidationException, "Expected the following values to be invalid for \"last_name\": \"\", nil, \"Something\"", fn ->
       ValidField.with_changeset(%Model{})
       |> ValidField.assert_invalid_field(:last_name, ["", nil, "Something"])
     end
 
-    assert_raise ExUnit.AssertionError, "Expected the following values to be invalid for \"title\": \"\", nil, \"Something else\"", fn ->
+    assert_raise ValidField.ValidationException, "Expected the following values to be invalid for \"title\": \"\", nil, \"Something else\"", fn ->
       ValidField.with_changeset(%Model{})
       |> ValidField.assert_invalid_field(:title, ["", nil, "Something else"])
     end
@@ -29,7 +29,7 @@ defmodule ValidFieldTest do
     ValidField.with_changeset(%Model{first_name: "Test"})
     |> ValidField.assert_valid_field(:first_name)
 
-    assert_raise ExUnit.AssertionError, "Expected the following values to be valid for \"first_name\": nil", fn ->
+    assert_raise ValidField.ValidationException, "Expected the following values to be valid for \"first_name\": nil", fn ->
       ValidField.with_changeset(%Model{})
       |> ValidField.assert_valid_field(:first_name)
     end
@@ -39,7 +39,7 @@ defmodule ValidFieldTest do
     ValidField.with_changeset(%Model{first_name: "Test", last_name: "Something", title: "Something else"})
     |> ValidField.assert_valid_fields([:first_name, :last_name, :title])
 
-    assert_raise ExUnit.AssertionError, "Expected the following values to be valid for \"first_name\": nil", fn ->
+    assert_raise ValidField.ValidationException, "Expected the following values to be valid for \"first_name\": nil", fn ->
       ValidField.with_changeset(%Model{})
       |> ValidField.assert_valid_fields([:first_name, :last_name, :title])
     end
@@ -49,7 +49,7 @@ defmodule ValidFieldTest do
     ValidField.with_changeset(%Model{})
     |> ValidField.assert_invalid_field(:first_name, ["", nil])
 
-    assert_raise ExUnit.AssertionError, "Expected the following values to be valid for \"first_name\": \"\", nil", fn ->
+    assert_raise ValidField.ValidationException, "Expected the following values to be valid for \"first_name\": \"\", nil", fn ->
       ValidField.with_changeset(%Model{})
       |> ValidField.assert_valid_field(:first_name, ["", nil])
     end
@@ -59,7 +59,7 @@ defmodule ValidFieldTest do
     ValidField.with_changeset(%Model{})
     |> ValidField.assert_invalid_field(:first_name)
 
-    assert_raise ExUnit.AssertionError, "Expected the following values to be invalid for \"first_name\": \"Test\"", fn ->
+    assert_raise ValidField.ValidationException, "Expected the following values to be invalid for \"first_name\": \"Test\"", fn ->
       ValidField.with_changeset(%Model{first_name: "Test"})
       |> ValidField.assert_invalid_field(:first_name)
     end
@@ -69,7 +69,7 @@ defmodule ValidFieldTest do
     ValidField.with_changeset(%Model{})
     |> ValidField.assert_invalid_fields([:first_name])
 
-    assert_raise ExUnit.AssertionError, "Expected the following values to be invalid for \"first_name\": \"Test\"", fn ->
+    assert_raise ValidField.ValidationException, "Expected the following values to be invalid for \"first_name\": \"Test\"", fn ->
       ValidField.with_changeset(%Model{first_name: "Test"})
       |> ValidField.assert_invalid_fields([:first_name])
     end
@@ -79,7 +79,7 @@ defmodule ValidFieldTest do
     custom_changeset_function = ValidField.with_changeset(%Model{}, &Model.changeset/2)
     |> ValidField.assert_invalid_field(:first_name, ["", nil])
 
-    assert_raise ExUnit.AssertionError, "Expected the following values to be valid for \"first_name\": \"\", nil", fn ->
+    assert_raise ValidField.ValidationException, "Expected the following values to be valid for \"first_name\": \"\", nil", fn ->
       custom_changeset_function
       |> ValidField.assert_valid_field(:first_name, ["", nil])
     end
@@ -89,12 +89,12 @@ defmodule ValidFieldTest do
     ValidField.with_changeset(%Model{})
     |> ValidField.assert_field(:first_name, ["Test", "Good Value"], ["", nil])
 
-    assert_raise ExUnit.AssertionError, "Expected the following values to be valid for \"first_name\": \"\", nil", fn ->
+    assert_raise ValidField.ValidationException, "Expected the following values to be valid for \"first_name\": \"\", nil", fn ->
       ValidField.with_changeset(%Model{})
       |> ValidField.assert_field(:first_name, ["", nil], ["", nil])
     end
 
-    assert_raise ExUnit.AssertionError, "Expected the following values to be invalid for \"first_name\": \"Test\", \"Good Value\"", fn ->
+    assert_raise ValidField.ValidationException, "Expected the following values to be invalid for \"first_name\": \"Test\", \"Good Value\"", fn ->
       ValidField.with_changeset(%Model{})
       |> ValidField.assert_field(:first_name, ["Test", "Good Value"], ["Test", "Good Value"])
     end

--- a/test/valid_field_test.exs
+++ b/test/valid_field_test.exs
@@ -9,17 +9,17 @@ defmodule ValidFieldTest do
     |> ValidField.assert_valid_field(:last_name, ["", nil, "Something"])
     |> ValidField.assert_valid_field(:title, ["", nil, "Something else"])
 
-    assert_raise ValidField.ValidationException, "Expected the following values to be invalid for \"first_name\": \"Test\", \"Good Value\"", fn ->
+    assert_raise ValidField.ValidationError, "Expected the following values to be invalid for \"first_name\": \"Test\", \"Good Value\"", fn ->
       ValidField.with_changeset(%Model{})
       |> ValidField.assert_invalid_field(:first_name, ["Test", "Good Value"])
     end
 
-    assert_raise ValidField.ValidationException, "Expected the following values to be invalid for \"last_name\": \"\", nil, \"Something\"", fn ->
+    assert_raise ValidField.ValidationError, "Expected the following values to be invalid for \"last_name\": \"\", nil, \"Something\"", fn ->
       ValidField.with_changeset(%Model{})
       |> ValidField.assert_invalid_field(:last_name, ["", nil, "Something"])
     end
 
-    assert_raise ValidField.ValidationException, "Expected the following values to be invalid for \"title\": \"\", nil, \"Something else\"", fn ->
+    assert_raise ValidField.ValidationError, "Expected the following values to be invalid for \"title\": \"\", nil, \"Something else\"", fn ->
       ValidField.with_changeset(%Model{})
       |> ValidField.assert_invalid_field(:title, ["", nil, "Something else"])
     end
@@ -29,7 +29,7 @@ defmodule ValidFieldTest do
     ValidField.with_changeset(%Model{first_name: "Test"})
     |> ValidField.assert_valid_field(:first_name)
 
-    assert_raise ValidField.ValidationException, "Expected the following values to be valid for \"first_name\": nil", fn ->
+    assert_raise ValidField.ValidationError, "Expected the following values to be valid for \"first_name\": nil", fn ->
       ValidField.with_changeset(%Model{})
       |> ValidField.assert_valid_field(:first_name)
     end
@@ -39,7 +39,7 @@ defmodule ValidFieldTest do
     ValidField.with_changeset(%Model{first_name: "Test", last_name: "Something", title: "Something else"})
     |> ValidField.assert_valid_fields([:first_name, :last_name, :title])
 
-    assert_raise ValidField.ValidationException, "Expected the following values to be valid for \"first_name\": nil", fn ->
+    assert_raise ValidField.ValidationError, "Expected the following values to be valid for \"first_name\": nil", fn ->
       ValidField.with_changeset(%Model{})
       |> ValidField.assert_valid_fields([:first_name, :last_name, :title])
     end
@@ -49,7 +49,7 @@ defmodule ValidFieldTest do
     ValidField.with_changeset(%Model{})
     |> ValidField.assert_invalid_field(:first_name, ["", nil])
 
-    assert_raise ValidField.ValidationException, "Expected the following values to be valid for \"first_name\": \"\", nil", fn ->
+    assert_raise ValidField.ValidationError, "Expected the following values to be valid for \"first_name\": \"\", nil", fn ->
       ValidField.with_changeset(%Model{})
       |> ValidField.assert_valid_field(:first_name, ["", nil])
     end
@@ -59,7 +59,7 @@ defmodule ValidFieldTest do
     ValidField.with_changeset(%Model{})
     |> ValidField.assert_invalid_field(:first_name)
 
-    assert_raise ValidField.ValidationException, "Expected the following values to be invalid for \"first_name\": \"Test\"", fn ->
+    assert_raise ValidField.ValidationError, "Expected the following values to be invalid for \"first_name\": \"Test\"", fn ->
       ValidField.with_changeset(%Model{first_name: "Test"})
       |> ValidField.assert_invalid_field(:first_name)
     end
@@ -69,7 +69,7 @@ defmodule ValidFieldTest do
     ValidField.with_changeset(%Model{})
     |> ValidField.assert_invalid_fields([:first_name])
 
-    assert_raise ValidField.ValidationException, "Expected the following values to be invalid for \"first_name\": \"Test\"", fn ->
+    assert_raise ValidField.ValidationError, "Expected the following values to be invalid for \"first_name\": \"Test\"", fn ->
       ValidField.with_changeset(%Model{first_name: "Test"})
       |> ValidField.assert_invalid_fields([:first_name])
     end
@@ -79,7 +79,7 @@ defmodule ValidFieldTest do
     custom_changeset_function = ValidField.with_changeset(%Model{}, &Model.changeset/2)
     |> ValidField.assert_invalid_field(:first_name, ["", nil])
 
-    assert_raise ValidField.ValidationException, "Expected the following values to be valid for \"first_name\": \"\", nil", fn ->
+    assert_raise ValidField.ValidationError, "Expected the following values to be valid for \"first_name\": \"\", nil", fn ->
       custom_changeset_function
       |> ValidField.assert_valid_field(:first_name, ["", nil])
     end
@@ -89,12 +89,12 @@ defmodule ValidFieldTest do
     ValidField.with_changeset(%Model{})
     |> ValidField.assert_field(:first_name, ["Test", "Good Value"], ["", nil])
 
-    assert_raise ValidField.ValidationException, "Expected the following values to be valid for \"first_name\": \"\", nil", fn ->
+    assert_raise ValidField.ValidationError, "Expected the following values to be valid for \"first_name\": \"\", nil", fn ->
       ValidField.with_changeset(%Model{})
       |> ValidField.assert_field(:first_name, ["", nil], ["", nil])
     end
 
-    assert_raise ValidField.ValidationException, "Expected the following values to be invalid for \"first_name\": \"Test\", \"Good Value\"", fn ->
+    assert_raise ValidField.ValidationError, "Expected the following values to be invalid for \"first_name\": \"Test\", \"Good Value\"", fn ->
       ValidField.with_changeset(%Model{})
       |> ValidField.assert_field(:first_name, ["Test", "Good Value"], ["Test", "Good Value"])
     end


### PR DESCRIPTION
This removes relyon on ex_unit's assert in favor of custom error struct. Done per discussion on https://github.com/DockYard/valid_field/pull/16#issuecomment-230847460
