### PR TITLE
Fix error when stringifying structs

### DIFF
--- a/lib/valid_field.ex
+++ b/lib/valid_field.ex
@@ -199,6 +199,7 @@ defmodule ValidField do
     do: Atom.to_string(field)
   defp stringify_field(field) when is_binary(field), do: field
 
+  defp stringify_keys(%{__struct__: _struct} = struct), do: struct
   defp stringify_keys(map) when is_map(map),
     do: Enum.into(map, %{}, fn({key, value}) ->
       {stringify_field(key), stringify_keys(value)}

--- a/test/support/model.ex
+++ b/test/support/model.ex
@@ -8,6 +8,7 @@ defmodule ValidField.Support.Model do
     field :title, :string
     field :password, :string
     field :password_confirmation
+    field :date_of_birth, Ecto.DateTime
 
     timestamps
   end

--- a/test/valid_field_test.exs
+++ b/test/valid_field_test.exs
@@ -23,6 +23,12 @@ defmodule ValidFieldTest do
       ValidField.with_changeset(%Model{})
       |> ValidField.assert_invalid_field(:title, ["", nil, "Something else"])
     end
+
+    assert_raise ValidField.ValidationError, "Expected the following values to be invalid for \"date_of_birth\": #Ecto.Date<2016-08-23>", fn ->
+      %Model{}
+      |> ValidField.with_changeset()
+      |> ValidField.assert_invalid_field(:date_of_birth, [Ecto.Date.utc])
+    end
   end
 
   test "valid field with no values passed" do


### PR DESCRIPTION
When trying to stringify a struct an error is raised because structs
don't implement enumerable by default. This happens because using
`Kernel.is_map/1` matches both structs and maps.

The fix is to pattern match against `%{__struct__: _struct}` before
using a guard with `is_map`.

Let me know if this solution works out or if there's a better alternative, thanks!
