### PR TITLE
Call `Ecto.Date.utc` with ()

### DIFF
--- a/test/valid_field_test.exs
+++ b/test/valid_field_test.exs
@@ -27,7 +27,7 @@ defmodule ValidFieldTest do
     assert_raise ValidField.ValidationError, "Expected the following values to be invalid for \"date_of_birth\": #Ecto.Date<2016-08-23>", fn ->
       %Model{}
       |> ValidField.with_changeset()
-      |> ValidField.assert_invalid_field(:date_of_birth, [Ecto.Date.utc])
+      |> ValidField.assert_invalid_field(:date_of_birth, [Ecto.Date.utc()])
     end
   end
 


### PR DESCRIPTION
This adds missing parentheses to the `Ecto.Date.utc` function call.
