### PR TITLE
Updates package version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add valid_field to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:valid_field, "~> 0.2.0", only: :test}]
+  [{:valid_field, "~> 0.4.0", only: :test}]
 end
 ```
 


### PR DESCRIPTION
Tiny update so the readme has the most up to date package version – otherwise you get this error with Ecto 2:

```
Failed to use "ecto" (version 2.0.5) because
  ecto_enum (version 0.3.1) requires >= 0.13.1
  phoenix_ecto (version 3.0.1) requires ~> 2.0
  valid_field (version 0.4.0) requires ~> 1.1.8
  mix.lock specifies 2.0.5
```