### PR TITLE
Support embeds

### DIFF
--- a/lib/valid_field.ex
+++ b/lib/valid_field.ex
@@ -191,8 +191,9 @@ defmodule ValidField do
       |> Map.put(field, value)
       |> stringify_keys()
 
-    changeset.(model, params).errors
-    |> Keyword.has_key?(field)
+    changeset.(model, params)
+    |> Ecto.Changeset.traverse_errors(fn _ -> nil end)
+    |> Map.has_key?(field)
   end
 
   defp invalid_for?(%{data: model, changeset_func: changeset}, field, value),

--- a/test/support/embedded_model.ex
+++ b/test/support/embedded_model.ex
@@ -1,0 +1,21 @@
+defmodule ValidField.Support.EmbeddedModel do
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias ValidField.Support.EmbeddedModel
+
+  embedded_schema do
+    field(:street, :string)
+    field(:city, :string)
+    field(:postcode, :string)
+
+    timestamps()
+  end
+
+  def changeset(%EmbeddedModel{} = embedded_model, params \\ :empty) do
+    embedded_model
+    |> cast(params, [:street, :city])
+    |> validate_required([:street, :city])
+  end
+end

--- a/test/support/embedded_model.ex
+++ b/test/support/embedded_model.ex
@@ -3,7 +3,6 @@ defmodule ValidField.Support.EmbeddedModel do
 
   import Ecto.Changeset
 
-
   embedded_schema do
     field(:street, :string)
     field(:city, :string)

--- a/test/support/embedded_model.ex
+++ b/test/support/embedded_model.ex
@@ -3,7 +3,6 @@ defmodule ValidField.Support.EmbeddedModel do
 
   import Ecto.Changeset
 
-  alias ValidField.Support.EmbeddedModel
 
   embedded_schema do
     field(:street, :string)

--- a/test/support/embedded_model.ex
+++ b/test/support/embedded_model.ex
@@ -12,7 +12,7 @@ defmodule ValidField.Support.EmbeddedModel do
     timestamps()
   end
 
-  def changeset(%EmbeddedModel{} = embedded_model, params \\ :empty) do
+  def changeset(%__MODULE__{} = embedded_model, params \\ :empty) do
     embedded_model
     |> cast(params, [:street, :city])
     |> validate_required([:street, :city])

--- a/test/support/model.ex
+++ b/test/support/model.ex
@@ -2,6 +2,8 @@ defmodule ValidField.Support.Model do
   use Ecto.Schema
   import Ecto.Changeset
 
+  alias ValidField.Support.EmbeddedModel
+
   schema "contacts" do
     field(:first_name, :string)
     field(:last_name, :string)
@@ -9,6 +11,7 @@ defmodule ValidField.Support.Model do
     field(:password, :string)
     field(:password_confirmation)
     field(:date_of_birth, :date)
+    embeds_one(:address, EmbeddedModel)
 
     timestamps()
   end
@@ -26,6 +29,7 @@ defmodule ValidField.Support.Model do
     |> validate_required([:first_name])
     |> validate_length(:first_name, min: 1)
     |> validate_confirmation(:password)
+    |> cast_embed(:address)
   end
 
   def other_changeset(model, params) do

--- a/test/valid_field_test.exs
+++ b/test/valid_field_test.exs
@@ -8,6 +8,7 @@ defmodule ValidFieldTest do
     |> ValidField.assert_valid_field(:first_name, ["Test", "Good Value"])
     |> ValidField.assert_valid_field(:last_name, ["", nil, "Something"])
     |> ValidField.assert_valid_field(:title, ["", nil, "Something else"])
+    |> ValidField.assert_valid_field(:address, [nil, %{city: "Boston", street: "Tremont St"}])
 
     assert_raise ValidField.ValidationError,
                  "Expected the following values to be invalid for \"first_name\": \"Test\", \"Good Value\"",
@@ -40,6 +41,17 @@ defmodule ValidFieldTest do
                    %Model{}
                    |> ValidField.with_changeset()
                    |> ValidField.assert_invalid_field(:date_of_birth, [date])
+                 end
+
+    assert_raise ValidField.ValidationError,
+                 "Expected the following values to be invalid for \"address\": nil, %{city: \"Boston\", street: \"Tremont St\"}",
+                 fn ->
+                   %Model{}
+                   |> ValidField.with_changeset()
+                   |> ValidField.assert_invalid_field(:address, [
+                     nil,
+                     %{city: "Boston", street: "Tremont St"}
+                   ])
                  end
   end
 
@@ -74,12 +86,20 @@ defmodule ValidFieldTest do
   test "invalid field values" do
     ValidField.with_changeset(%Model{})
     |> ValidField.assert_invalid_field(:first_name, ["", nil])
+    |> ValidField.assert_invalid_field(:address, [%{city: "Boston", street: ""}])
 
     assert_raise ValidField.ValidationError,
                  "Expected the following values to be valid for \"first_name\": \"\", nil",
                  fn ->
                    ValidField.with_changeset(%Model{})
                    |> ValidField.assert_valid_field(:first_name, ["", nil])
+                 end
+
+    assert_raise ValidField.ValidationError,
+                 "Expected the following values to be valid for \"address\": %{city: \"Boston\", street: \"\"}",
+                 fn ->
+                   ValidField.with_changeset(%Model{})
+                   |> ValidField.assert_valid_field(:address, [%{city: "Boston", street: ""}])
                  end
   end
 


### PR DESCRIPTION
Errors for nested schemas don't get added to `changeset.errors` but the field in `changeset.changes`. Because of this, ValidField didn't work for nested schemas. Getting errors from `Ecto.Changesets.traverse_errors/2` instead of using `changeset.errors` fixes this issue (https://github.com/DockYard/valid_field/issues/29).